### PR TITLE
Add the ability to specify custom formats for columns

### DIFF
--- a/excelr.py
+++ b/excelr.py
@@ -112,7 +112,6 @@ def to_excel(
                         value = '-'
 
                     if data_type == 'b':
-                        assert isinstance(value, bool)
                         value = int(value)
 
                     # use inlineStr so that we don't need to keep track of
@@ -120,7 +119,6 @@ def to_excel(
                     # we need. Since xlsx is a compressed format this shouldn't
                     # affect the size of the generated file too much.
                     elif data_type == 'inlineStr':
-                        assert isinstance(value, str)
                         value = _xml_escape(value)
                         tag_start, tag_end = '<is><t>', '</t></is>'
 

--- a/excelr.py
+++ b/excelr.py
@@ -5,7 +5,7 @@ from datetime import date
 from itertools import product
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Union, IO, Iterable, Optional
+from typing import Union, IO, Iterable, Optional, Literal
 from zipfile import ZipFile, ZIP_DEFLATED
 
 
@@ -46,13 +46,20 @@ Value = Optional[Union[bool, float, int, date, str]]
 Rows = Iterable[Iterable[Value]]
 
 
-def to_excel(output: Union[StrPath, IO[bytes]], rows: Rows):
+def to_excel(
+    output: Union[StrPath, IO[bytes]],
+    rows: Rows,
+    column_format_codes: dict[int, str] = None,
+) -> Union[StrPath, IO[bytes]]:
     """
     Create a simple excel file from the given rows, writing to the desired
     output file.
 
     :param output: path to file, or file like object.
     :param rows: Iterable of Iterables containing rows / columns to export
+    :param column_format_codes: Dictionary mapping column indexes to format codes, see
+                                https://www.ecma-international.org/publications-and-standards/standards/ecma-376/
+                                for information about supported format codes.
     """
     with TemporaryDirectory() as d:
 
@@ -65,6 +72,28 @@ def to_excel(output: Union[StrPath, IO[bytes]], rows: Rows):
         for file in files:
             shutil.copy(src_path / file, dst_path / file)
 
+        # No need to repeat format codes when they occur for multiple columns
+        _column_format_codes = column_format_codes or {}
+        format_codes = list(set(_column_format_codes.values()))
+
+        # generate the indexes which will be used to reference the actual styles
+        style_indexes = {
+            column_index: format_codes.index(format_code) + 1  # +1 to skip 'General'
+            for column_index, format_code in _column_format_codes.items()
+        }
+
+        # Here we read the styles file into memory, however the file is small
+        num_fmts = _get_num_fmts_xml(format_codes)
+        cell_xfs = _get_cell_xfs(len(format_codes))
+
+        styles_path = Path(dst_path / 'xl' / 'styles.xml')
+        styles_path.write_text(
+            styles_path
+            .read_text()
+            .replace("{{ numFmts }}", num_fmts)
+            .replace("{{ cellXfs }}", cell_xfs)
+        )
+
         # the sheet1.xml file is incomplete, fill it in now by writing
         # output cells to the worksheet (template already contains <sheetData>
         # and <worksheet> xml opening tags)
@@ -74,7 +103,7 @@ def to_excel(output: Union[StrPath, IO[bytes]], rows: Rows):
 
                 f.write(f'<row r="{row}">')
 
-                for col, value in zip(COLUMN_COORDINATES, row_values):
+                for i, (col, value) in enumerate(zip(COLUMN_COORDINATES, row_values)):
 
                     data_type = TYPE_MAP.get(type(value), 'inlineStr')
                     tag_start, tag_end = '<v>', '</v>'
@@ -95,7 +124,9 @@ def to_excel(output: Union[StrPath, IO[bytes]], rows: Rows):
                         value = _xml_escape(value)
                         tag_start, tag_end = '<is><t>', '</t></is>'
 
-                    f.write(f'<c r="{col}{row}" t="{data_type}">{tag_start}{value}{tag_end}</c>')
+                    f.write(f'<c r="{col}{row}" '
+                            f's="{style_indexes.get(i, 0)}" '
+                            f't="{data_type}">{tag_start}{value}{tag_end}</c>')
 
                 f.write(f'</row>')
 
@@ -106,6 +137,46 @@ def to_excel(output: Union[StrPath, IO[bytes]], rows: Rows):
         with ZipFile(output, 'w', compression=ZIP_DEFLATED) as zf:
             for file in files:
                 zf.write(dst_path / file, file)
+
+        return output
+
+
+def _get_num_fmts_xml(column_format_codes: list[str]) -> str:
+    """
+    Get the xml fragment for the numFmts part of styles.xml
+    """
+    _column_format_codes = ['General'] + column_format_codes
+    return ''.join((
+        f'<numFmts count="{len(_column_format_codes)}">',
+        *(
+            f'<numFmt numFmtId="{num_fmt_id}" formatCode="{format_code}"/>'
+            for num_fmt_id, format_code in enumerate(_column_format_codes, start=164)
+        ),
+        f'</numFmts>',
+    ))
+
+
+def _get_cell_xfs(num_column_format_codes: int) -> str:
+    """
+    Get the xml fragment for the cellXfs part of styles.xml
+    """
+    _num_column_format_codes = num_column_format_codes + 1  # + 1 for General
+    return ''.join((
+        f'<cellXfs count="{_num_column_format_codes}">',
+        *(
+            f"""
+                <xf numFmtId="{num_fmt_id + 164}" fontId="0" fillId="0" borderId="0" xfId="0" 
+                    applyFont="false" applyBorder="false" applyAlignment="false" 
+                    applyProtection="false">
+                    <alignment horizontal="general" vertical="bottom" textRotation="0" 
+                               wrapText="false" indent="0" shrinkToFit="false"/>
+                    <protection locked="true" hidden="false"/>
+                </xf>
+            """
+            for num_fmt_id in range(_num_column_format_codes)
+        ),
+        f'</cellXfs>',
+    ))
 
 
 def _xml_escape(value: str) -> str:

--- a/tests/test_excelr.py
+++ b/tests/test_excelr.py
@@ -9,14 +9,51 @@ from excelr import to_excel
 
 class Tests(TestCase):
 
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # create an excel file and parse the styles and worksheets
+        with BytesIO() as io:
+            to_excel(io, ['abc', [1, 2, 3]], {0: '0.00%', 2: '0.00%'})
+            io.seek(0)
+            with ZipFile(io) as z:
+                with z.open('xl/styles.xml') as f:
+                    cls.styles = ElementTree.fromstring(f.read().decode())
+                with z.open('xl/worksheets/sheet1.xml') as f:
+                    cls.sheet1 = ElementTree.fromstring(f.read().decode())
+
+    def test_custom_format_code_should_be_in_styles(self):
+        """
+        Verify that styles.xml is generated correctly when a custom
+        format is given.
+        """
+        num_fmts = self.styles[0]
+        self.assertEqual(num_fmts.attrib['count'], "2")
+        num_fmt = self.styles[0][0]
+        self.assertEqual(num_fmt.attrib['numFmtId'], "164")
+        self.assertEqual(num_fmt.attrib['formatCode'], 'General')
+        num_fmt = self.styles[0][1]
+        self.assertEqual(num_fmt.attrib['numFmtId'], "165")
+        self.assertEqual(num_fmt.attrib['formatCode'], '0.00%')
+        cell_xfs = self.styles[5]
+        self.assertEqual(cell_xfs.attrib['count'], "2")
+        self.assertEqual(cell_xfs[0].attrib['numFmtId'], "164")
+        self.assertEqual(cell_xfs[1].attrib['numFmtId'], "165")
+
     def test_strings_should_be_inline(self):
         """
         Verify that strings are written as inlineStr.
         """
-        with BytesIO() as io:
-            to_excel(io, ['a'])
-            io.seek(0)
-            with ZipFile(io) as z:
-                with z.open('xl/worksheets/sheet1.xml') as f:
-                    tree = ElementTree.fromstring(f.read().decode())
-                    self.assertEqual(tree[4][0][0].attrib['t'], 'inlineStr')
+        self.assertEqual(self.sheet1[4][0][0].attrib['t'], 'inlineStr')
+
+    def test_custom_format_code_should_be_selected_in_worksheet(self):
+        """
+        Verify that custom format codes are properly selected in
+        sheet.xml
+        """
+        # first column should have custom format
+        self.assertEqual(self.sheet1[4][0][0].attrib['s'], "1")
+        # second column should not have custom format
+        self.assertEqual(self.sheet1[4][0][1].attrib['s'], "0")
+        # third column should have custom format
+        self.assertEqual(self.sheet1[4][0][2].attrib['s'], "1")

--- a/xlsx_template/xl/styles.xml
+++ b/xlsx_template/xl/styles.xml
@@ -1,2 +1,99 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><numFmts count="1"><numFmt numFmtId="164" formatCode="General"/></numFmts><fonts count="4"><font><sz val="10"/><name val="Arial"/><family val="2"/></font><font><sz val="10"/><name val="Arial"/><family val="0"/></font><font><sz val="10"/><name val="Arial"/><family val="0"/></font><font><sz val="10"/><name val="Arial"/><family val="0"/></font></fonts><fills count="2"><fill><patternFill patternType="none"/></fill><fill><patternFill patternType="gray125"/></fill></fills><borders count="1"><border diagonalUp="false" diagonalDown="false"><left/><right/><top/><bottom/><diagonal/></border></borders><cellStyleXfs count="20"><xf numFmtId="164" fontId="0" fillId="0" borderId="0" applyFont="true" applyBorder="true" applyAlignment="true" applyProtection="true"><alignment horizontal="general" vertical="bottom" textRotation="0" wrapText="false" indent="0" shrinkToFit="false"/><protection locked="true" hidden="false"/></xf><xf numFmtId="0" fontId="1" fillId="0" borderId="0" applyFont="true" applyBorder="false" applyAlignment="false" applyProtection="false"></xf><xf numFmtId="0" fontId="1" fillId="0" borderId="0" applyFont="true" applyBorder="false" applyAlignment="false" applyProtection="false"></xf><xf numFmtId="0" fontId="2" fillId="0" borderId="0" applyFont="true" applyBorder="false" applyAlignment="false" applyProtection="false"></xf><xf numFmtId="0" fontId="2" fillId="0" borderId="0" applyFont="true" applyBorder="false" applyAlignment="false" applyProtection="false"></xf><xf numFmtId="0" fontId="0" fillId="0" borderId="0" applyFont="true" applyBorder="false" applyAlignment="false" applyProtection="false"></xf><xf numFmtId="0" fontId="0" fillId="0" borderId="0" applyFont="true" applyBorder="false" applyAlignment="false" applyProtection="false"></xf><xf numFmtId="0" fontId="0" fillId="0" borderId="0" applyFont="true" applyBorder="false" applyAlignment="false" applyProtection="false"></xf><xf numFmtId="0" fontId="0" fillId="0" borderId="0" applyFont="true" applyBorder="false" applyAlignment="false" applyProtection="false"></xf><xf numFmtId="0" fontId="0" fillId="0" borderId="0" applyFont="true" applyBorder="false" applyAlignment="false" applyProtection="false"></xf><xf numFmtId="0" fontId="0" fillId="0" borderId="0" applyFont="true" applyBorder="false" applyAlignment="false" applyProtection="false"></xf><xf numFmtId="0" fontId="0" fillId="0" borderId="0" applyFont="true" applyBorder="false" applyAlignment="false" applyProtection="false"></xf><xf numFmtId="0" fontId="0" fillId="0" borderId="0" applyFont="true" applyBorder="false" applyAlignment="false" applyProtection="false"></xf><xf numFmtId="0" fontId="0" fillId="0" borderId="0" applyFont="true" applyBorder="false" applyAlignment="false" applyProtection="false"></xf><xf numFmtId="0" fontId="0" fillId="0" borderId="0" applyFont="true" applyBorder="false" applyAlignment="false" applyProtection="false"></xf><xf numFmtId="43" fontId="1" fillId="0" borderId="0" applyFont="true" applyBorder="false" applyAlignment="false" applyProtection="false"></xf><xf numFmtId="41" fontId="1" fillId="0" borderId="0" applyFont="true" applyBorder="false" applyAlignment="false" applyProtection="false"></xf><xf numFmtId="44" fontId="1" fillId="0" borderId="0" applyFont="true" applyBorder="false" applyAlignment="false" applyProtection="false"></xf><xf numFmtId="42" fontId="1" fillId="0" borderId="0" applyFont="true" applyBorder="false" applyAlignment="false" applyProtection="false"></xf><xf numFmtId="9" fontId="1" fillId="0" borderId="0" applyFont="true" applyBorder="false" applyAlignment="false" applyProtection="false"></xf></cellStyleXfs><cellXfs count="1"><xf numFmtId="164" fontId="0" fillId="0" borderId="0" xfId="0" applyFont="false" applyBorder="false" applyAlignment="false" applyProtection="false"><alignment horizontal="general" vertical="bottom" textRotation="0" wrapText="false" indent="0" shrinkToFit="false"/><protection locked="true" hidden="false"/></xf></cellXfs><cellStyles count="6"><cellStyle name="Normal" xfId="0" builtinId="0"/><cellStyle name="Comma" xfId="15" builtinId="3"/><cellStyle name="Comma [0]" xfId="16" builtinId="6"/><cellStyle name="Currency" xfId="17" builtinId="4"/><cellStyle name="Currency [0]" xfId="18" builtinId="7"/><cellStyle name="Percent" xfId="19" builtinId="5"/></cellStyles></styleSheet>
+<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+    {{ numFmts }}
+    <fonts count="4">
+        <font>
+            <sz val="10"/>
+            <name val="Arial"/>
+            <family val="2"/>
+            <charset val="1"/>
+        </font>
+        <font>
+            <sz val="10"/>
+            <name val="Arial"/>
+            <family val="0"/>
+        </font>
+        <font>
+            <sz val="10"/>
+            <name val="Arial"/>
+            <family val="0"/>
+        </font>
+        <font>
+            <sz val="10"/>
+            <name val="Arial"/>
+            <family val="0"/>
+        </font>
+    </fonts>
+    <fills count="2">
+        <fill>
+            <patternFill patternType="none"/>
+        </fill>
+        <fill>
+            <patternFill patternType="gray125"/>
+        </fill>
+    </fills>
+    <borders count="1">
+        <border diagonalUp="false" diagonalDown="false">
+            <left/>
+            <right/>
+            <top/>
+            <bottom/>
+            <diagonal/>
+        </border>
+    </borders>
+    <cellStyleXfs count="20">
+        <xf numFmtId="164" fontId="0" fillId="0" borderId="0" applyFont="true" applyBorder="true" applyAlignment="true"
+            applyProtection="true">
+            <alignment horizontal="general" vertical="bottom" textRotation="0" wrapText="false" indent="0"
+                       shrinkToFit="false"/>
+            <protection locked="true" hidden="false"/>
+        </xf>
+        <xf numFmtId="0" fontId="1" fillId="0" borderId="0" applyFont="true" applyBorder="false" applyAlignment="false"
+            applyProtection="false"></xf>
+        <xf numFmtId="0" fontId="1" fillId="0" borderId="0" applyFont="true" applyBorder="false" applyAlignment="false"
+            applyProtection="false"></xf>
+        <xf numFmtId="0" fontId="2" fillId="0" borderId="0" applyFont="true" applyBorder="false" applyAlignment="false"
+            applyProtection="false"></xf>
+        <xf numFmtId="0" fontId="2" fillId="0" borderId="0" applyFont="true" applyBorder="false" applyAlignment="false"
+            applyProtection="false"></xf>
+        <xf numFmtId="0" fontId="0" fillId="0" borderId="0" applyFont="true" applyBorder="false" applyAlignment="false"
+            applyProtection="false"></xf>
+        <xf numFmtId="0" fontId="0" fillId="0" borderId="0" applyFont="true" applyBorder="false" applyAlignment="false"
+            applyProtection="false"></xf>
+        <xf numFmtId="0" fontId="0" fillId="0" borderId="0" applyFont="true" applyBorder="false" applyAlignment="false"
+            applyProtection="false"></xf>
+        <xf numFmtId="0" fontId="0" fillId="0" borderId="0" applyFont="true" applyBorder="false" applyAlignment="false"
+            applyProtection="false"></xf>
+        <xf numFmtId="0" fontId="0" fillId="0" borderId="0" applyFont="true" applyBorder="false" applyAlignment="false"
+            applyProtection="false"></xf>
+        <xf numFmtId="0" fontId="0" fillId="0" borderId="0" applyFont="true" applyBorder="false" applyAlignment="false"
+            applyProtection="false"></xf>
+        <xf numFmtId="0" fontId="0" fillId="0" borderId="0" applyFont="true" applyBorder="false" applyAlignment="false"
+            applyProtection="false"></xf>
+        <xf numFmtId="0" fontId="0" fillId="0" borderId="0" applyFont="true" applyBorder="false" applyAlignment="false"
+            applyProtection="false"></xf>
+        <xf numFmtId="0" fontId="0" fillId="0" borderId="0" applyFont="true" applyBorder="false" applyAlignment="false"
+            applyProtection="false"></xf>
+        <xf numFmtId="0" fontId="0" fillId="0" borderId="0" applyFont="true" applyBorder="false" applyAlignment="false"
+            applyProtection="false"></xf>
+        <xf numFmtId="43" fontId="1" fillId="0" borderId="0" applyFont="true" applyBorder="false" applyAlignment="false"
+            applyProtection="false"></xf>
+        <xf numFmtId="41" fontId="1" fillId="0" borderId="0" applyFont="true" applyBorder="false" applyAlignment="false"
+            applyProtection="false"></xf>
+        <xf numFmtId="44" fontId="1" fillId="0" borderId="0" applyFont="true" applyBorder="false" applyAlignment="false"
+            applyProtection="false"></xf>
+        <xf numFmtId="42" fontId="1" fillId="0" borderId="0" applyFont="true" applyBorder="false" applyAlignment="false"
+            applyProtection="false"></xf>
+        <xf numFmtId="9" fontId="1" fillId="0" borderId="0" applyFont="true" applyBorder="false" applyAlignment="false"
+            applyProtection="false"></xf>
+    </cellStyleXfs>
+        {{ cellXfs }}
+    <cellStyles count="6">
+        <cellStyle name="Normal" xfId="0" builtinId="0"/>
+        <cellStyle name="Comma" xfId="15" builtinId="3"/>
+        <cellStyle name="Comma [0]" xfId="16" builtinId="6"/>
+        <cellStyle name="Currency" xfId="17" builtinId="4"/>
+        <cellStyle name="Currency [0]" xfId="18" builtinId="7"/>
+        <cellStyle name="Percent" xfId="19" builtinId="5"/>
+    </cellStyles>
+</styleSheet>


### PR DESCRIPTION
Although excel uses numbers (rather than strings like csv) we still want percentages and dates to show up as such. This PR adds the ability to specify a "custom format" for columns (a dict mapping column id to a openxml format code). These formats are then exported to styles.xml and referenced in the actual celsls.